### PR TITLE
Set error in the GetChangedBlocks CR status

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -241,6 +241,14 @@ func (c *Controller) syncHandler(key string) error {
 	})
 	if err != nil {
 		klog.Errorf("Unable to get changed blocks from service: %v", err)
+		getChangedBlocks.Status.State = "Failed"
+		getChangedBlocks.Status.Error = err.Error()
+		getChangedBlocks.Status.ChangeBlockList = []differentialsnapshotv1alpha1.ChangedBlock{}
+		getChangedBlocks, err = c.updateGetChangedBlocksStatus(getChangedBlocks)
+		if err != nil {
+			klog.Errorf("unable to update the CBT status: %v", err)
+			return err
+		}
 		return err
 	}
 	klog.Infof("Processed GetChangedBlocks %#v", cbs)


### PR DESCRIPTION
Update `status.state` and `status.error` in case of GetChangedBlockses errors

#### Sample object specs with error
```
apiVersion: differentialsnapshot.example.com/v1alpha1
kind: GetChangedBlocks
metadata:
  creationTimestamp: "2022-04-29T12:40:19Z"
  generation: 1
  name: testing
  namespace: diffsnap
  resourceVersion: "5698720"
  uid: d5ecfc16-71bf-4c2c-9973-75391b825079
spec:
  maxEntries: 1000000
  snapshotBase: snap-0ce8d7f58c8b1b5b1
  snapshotTarget: snap-0e8831de19cac2852
status:
  changeBlockList: []
  error: Failed to query /cbt.csi.v1.DifferentialSnapshot/GetChangedBlocks    <- this error is injected for testing, the actual error msg will be different than this
  state: Failed
  timeout: 0
  volumeSize: 0

```