### PR TITLE
Update IAM policy to allow CBT actions

### DIFF
--- a/deploy/eks/iam-policy.json
+++ b/deploy/eks/iam-policy.json
@@ -4,6 +4,15 @@
     {
       "Effect": "Allow",
       "Action": [
+          "ebs:ListSnapshotBlocks",
+          "ebs:ListChangedBlocks",
+          "ebs:GetSnapshotBlock"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "ec2:CreateSnapshot",
         "ec2:AttachVolume",
         "ec2:DetachVolume",


### PR DESCRIPTION
This PR updates the IAM policy meant to be attached to the EBS CSI driver K8s service account with permissions to run CBT actions.